### PR TITLE
Add support for generating new migration classes with `wp migrate <name> --scaffold`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,5 @@ class AddPricingPage extends AbstractMigration {
 You can run specific migrations using the filename as an argument, eg. `wp dbi migrate AddCustomTable`.
 
 To rollback all migrations you can run `wp dbi migrate --rollback`, or just a specific migration `wp dbi migrate AddCustomTable --rollback`.
+
+To quickly scaffold a new migration you can run `wp dbi migrate <name> --scaffold`. For example, `wp dbi migration MyMigration --scaffold` will create a new class named `MyMigration` in the default migration files directory with the correct filename and all required boilerplate code.

--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -18,6 +18,9 @@ class Command extends \WP_CLI_Command {
 	 * [--setup]
 	 * : Set up the migrations table
 	 *
+	 * [--scaffold]
+	 * : Scaffold a new migration class using the migration stub
+	 *
 	 * @param array $args
 	 * @param array $assoc_args
 	 *
@@ -39,6 +42,20 @@ class Command extends \WP_CLI_Command {
 		$migration = null;
 		if ( ! empty( $args[0] ) ) {
 			$migration = $args[0];
+		}
+
+		if ( isset( $assoc_args['scaffold'] ) ) {
+			if ( ! $migration ) {
+				return \WP_CLI::error( 'Migration name must be specified when using --scaffold' );
+			}
+
+			$filename = $migrator->scaffold( $migration );
+
+			if ( is_wp_error( $filename ) ) {
+				return \WP_ClI::error( $filename->get_error_message() );
+			}
+
+			return \WP_CLI::success( "Created {$filename}!" );
 		}
 
 		$rollback = false;

--- a/stubs/migration.stub
+++ b/stubs/migration.stub
@@ -1,0 +1,19 @@
+<?php
+
+use DeliciousBrains\WPMigrations\Database\AbstractMigration;
+
+class {{ class }} extends AbstractMigration {
+
+	/**
+	 * Run the migration.
+	 */
+	public function run() {
+	}
+
+	/**
+	 * Optional: Roll back the migration.
+	 */
+	public function rollback() {
+	}
+
+}


### PR DESCRIPTION
Adds support for scaffolding a new migration class with `wp migrate MyMigration --scaffold` and updates the documentation accordingly.

By default the boilerplate code is generated using the template in the new "stubs" directory. The new `dbi_migration_stub_path` filter can be used to switch out the default stub template for a new one in advanced use cases.